### PR TITLE
Fix two bugs in router

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -286,6 +286,9 @@ class Router {
                 const contentType = request.headers.get('content-type');
                 if (request.method === HTTP_METHOD.POST && contentType === 'application/x-www-form-urlencoded') {
                     formData = await request.formData();
+                    // The original request's body is now consumed. Replace the request with
+                    // a clone using the parsed body, so that we can still pass it to fetch().
+                    request = new Request(request, {body: formData})
                 }
 
                 m = this._match(request, formData);
@@ -294,6 +297,7 @@ class Router {
                     handler = m.route.handler;
 
                     resolve(handler(m));
+                    return;
                 }
                 // Pass-through as no match
                 resolve(fetch(request));


### PR DESCRIPTION
*Disclaimer: I haven't really tested this and I may have misunderstood what the code was trying to do... but these looked like issues so I thought I'd suggest changes. Feel free to reject.*

1. After calling `request.formData()`, the `Request` object has been consumed. A subrequest call to `fetch(request)` will throw "TypeError: This readable stream is currently locked to a reader.". We can fix this by replacing the request with a new Request object that is built from the parsed form data.
2. In the case that a matching handler was found, the request was *also* still being passed to `fetch()`, but the response from `fetch()` was being thrown away (since only the first call to `resolve()` takes effect). I think the intent was not to call `fetch()` if there is a matching handler.